### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.7.4
 async-timeout==3.0.1
 asyncio==3.4.3
 attrs==20.3.0
-certifi==2020.12.5
+certifi==2023.7.22
 chardet==3.0.4
 idna==2.10
 m3u-parser==0.1.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2020.12.5
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2020.12.5 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS