### PR TITLE
fix(sec): upgrade aiohttp to 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.7.4
+aiohttp==3.8.5
 async-timeout==3.0.1
 asyncio==3.4.3
 attrs==20.3.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in aiohttp 3.7.4
- [CVE-2022-33124](https://www.oscs1024.com/hd/CVE-2022-33124)


### What did I do？
Upgrade aiohttp from 3.7.4 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS